### PR TITLE
Remove operator field

### DIFF
--- a/data/prison/prison.tsv
+++ b/data/prison/prison.tsv
@@ -1,154 +1,154 @@
-prison-estate	name	operator	start-date	end-date
-AC	HMP/YOI Altcourse	company:02984969		
-AS	HMP Ashfield	company:03403669		
-AG	HMP/YOI Askham Grange			
-AY	HMYOI Aylesbury			
-BF	HMP/YOI Bedford			
-BA	HMP/YOI Belmarsh			
-BW	HMP/YOI Berwyn			
-BM	HMP Birmingham	company:00390328		
-BH	HMP Blantyre House			
-BS	HMP/YOI Brinsford			
-BL	HMP/YOI Bristol			
-BX	HMP Brixton			
-BZ	HMP/YOI Bronzefield	company:04334205		
-BC	HMP Buckley Hall			
-BN	HMP/YOI Bullingdon			
-BR	HMP Bure			
-CF	HMP/YOI Cardiff			
-CW	HMP Channings Wood			
-CD	HMP/YOI Chelmsford			
-CL	HMP Coldingley			
-CK	HMYOI Cookham Wood			
-DA	HMP Dartmoor			
-DT	HMYOI Deerbolt			
-DN	HMP/YOI Doncaster	company:00242246		
-DG	HMP Dovegate	company:03471077		
-DW	HMP/YOI Downview			
-DH	HMP/YOI Drake Hall			
-DM	HMP/YOI Durham			
-ES	HMP/YOI East Sutton Park			
-EW	HMP/YOI Eastwood Park			
-EY	HMP/YOI Elmley			
-EE	HMP Erlestoke			
-EX	HMP/YOI Exeter			
-FS	HMP Featherstone			
-FM	HMYOI Feltham			
-FD	HMP Ford			
-FB	HMP/YOI Forest Bank	company:03509050		
-FH	HMP/YOI Foston Hall			
-FK	HMP Frankland			
-FN	HMP Full Sutton			
-GH	HMP Garth			
-GT	HMP Gartree			
-GP	HMP/YOI Glen Parva			
-GN	HMP Grendon/Spring Hill			
-GM	HMP Guys Marsh			
-HD	HMP/YOI Hatfield			
-HV	HMP Haverigg			
-HE	HMP/YOI Hewell			
-HO	HMP/YOI High Down			
-HP	HMP Highpoint			
-HI	HMP/YOI Hindley			
-HB	HMP/YOI Hollesley Bay			
-HH	HMP/YOI Holme House			
-HL	HMP/YOI Hull			
-HM	HMP Humber			
-HC	HMP Huntercombe			
-IS	HMP/YOI Isis			
-IW	HMP/YOI Isle of Wight			
-KM	HMP Kirkham			
-KV	HMP/YOI Kirklevington Grange			
-LF	HMP Lancaster Farms			
-LE	HMP Leeds			
-LC	HMP Leicester			
-LW	HMP/YOI Lewes			
-LY	HMP Leyhill			
-LI	HMP/YOI Lincoln			
-LH	HMP Lindholme			
-LT	HMP Littlehey			
-LP	HMP Liverpool			
-LL	HMP Long Lartin			
-LN	HMP/YOI Low Newton			
-LG	HMP Lowdham Grange	company:03154430		
-MS	HMP Maidstone			
-MR	HMP/YOI Manchester			
-MW	Medway STC			
-MD	HMP/YOI Moorland			
-MH	HMP Morton Hall			
-MH	HMIRC Morton Hall			
-NH	HMP/YOI New Hall			
-NS	HMP North Sea Camp			
-NL	HMP Northumberland	company:00842846		
-NW	HMP/YOI Norwich			
-NM	HMP/YOI Nottingham			
-OW	HMP Oakwood	company:00390328		
-ON	HMP Onley			
-PR	HMP/YOI Parc	company:03045222		
-PV	HMP/YOI Pentonville			
-PB	HMP/YOI Peterborough	company:04350276		
-PD	HMP/YOI Portland			
-PN	HMP/YOI Preston			
-RN	HMP Ranby			
-RS	HMP Risley			
-RC	HMP/YOI Rochester			
-RH	HMP Rye Hill	company:03682678		
-SD	HMP/YOI Send			
-SF	HMP Stafford			
-EH	HMP/YOI Standford Hill			
-SK	HMP Stocken			
-SH	HMP/YOI Stoke Heath			
-ST	HMP/YOI Styal			
-SU	HMP/YOI Sudbury			
-SL	HMP Swaleside			
-SW	HMP/YOI Swansea			
-SN	HMP/YOI Swinfen Hall			
-TS	HMP/YOI Thameside	company:07279250		
-MT	HMP The Mount			
-VE	HMP The Verne			
-VE	HMIRC The Verne			
-TC	HMP/YOI Thorn Cross			
-UK	HMP Usk and HMP/YOI Prescoed			
-WD	HMP Wakefield			
-WW	HMP/YOI Wandsworth			
-WI	HMP/YOI Warren Hill			
-WL	HMP Wayland			
-WE	HMP Wealstun			
-WN	HMYOI Werrington			
-WY	HMYOI Wetherby			
-WT	HMP Whatton			
-WR	HMP Whitemoor			
-WC	HMP/YOI Winchester			
-WH	HMP/YOI Woodhill			
-WS	HMP/YOI Wormwood Scrubs			
-WM	HMP/YOI Wymott			
-AK	HMP Acklington			2011-10-31
-AL	HMP Albany			2009-04
-AW	HMP Ashwell			2011-03
-BT	HMP Blakenhurst			2008-06-25
-BD	HMP Blundeston			2013-09
-BK	HMP Brockhill			2008-06-25
-BU	HMP Bullwood Hall			2013-01
-CH	HMP Camp Hill			2009-04
-CY	HMP Canterbury			2013-03-31
-CS	HMP Castington			2011-10-31
-DR	HMP Dorchester			2013-12
-DV	HMIRC Dover			2015
-NE	HMP Edmunds Hill			2011-04
-EV	HMP Everthorpe			2014-04
-GL	HMP Gloucester			2013
-HR	HMIRC Haslar			2015
-HG	HMP Hewell Grange			2008-06-25
-HY	HMP Holloway			2016-05
-KT	HMP Kennet			2016-12
-PT	HMP Kingston			2013-03-28
-LM	HMP Latchmere House			2011-09
-LA	HMP Lancaster			2011-03
-NN	HMP Northallerton			2013-12
-PK	HMP Parkhurst			2009-04
-RD	HMP Reading			2013-11
-SM	HMP Shepton Mallet			2013-02-28
-SY	HMP Shrewsbury			2013-03
-WA	HMP The Weare			2006
-WB	HMP Wellingborough			2012-12-21
-WO	HMP Wolds			2014-04
+prison-estate	name	start-date	end-date
+AC	HMP/YOI Altcourse
+AS	HMP Ashfield
+AG	HMP/YOI Askham Grange
+AY	HMYOI Aylesbury
+BF	HMP/YOI Bedford
+BA	HMP/YOI Belmarsh
+BW	HMP/YOI Berwyn
+BM	HMP Birmingham
+BH	HMP Blantyre House
+BS	HMP/YOI Brinsford
+BL	HMP/YOI Bristol
+BX	HMP Brixton
+BZ	HMP/YOI Bronzefield
+BC	HMP Buckley Hall
+BN	HMP/YOI Bullingdon
+BR	HMP Bure
+CF	HMP/YOI Cardiff
+CW	HMP Channings Wood
+CD	HMP/YOI Chelmsford
+CL	HMP Coldingley
+CK	HMYOI Cookham Wood
+DA	HMP Dartmoor
+DT	HMYOI Deerbolt
+DN	HMP/YOI Doncaster
+DG	HMP Dovegate
+DW	HMP/YOI Downview
+DH	HMP/YOI Drake Hall
+DM	HMP/YOI Durham
+ES	HMP/YOI East Sutton Park
+EW	HMP/YOI Eastwood Park
+EY	HMP/YOI Elmley
+EE	HMP Erlestoke
+EX	HMP/YOI Exeter
+FS	HMP Featherstone
+FM	HMYOI Feltham
+FD	HMP Ford
+FB	HMP/YOI Forest Bank
+FH	HMP/YOI Foston Hall
+FK	HMP Frankland
+FN	HMP Full Sutton
+GH	HMP Garth
+GT	HMP Gartree
+GP	HMP/YOI Glen Parva
+GN	HMP Grendon/Spring Hill
+GM	HMP Guys Marsh
+HD	HMP/YOI Hatfield
+HV	HMP Haverigg
+HE	HMP/YOI Hewell
+HO	HMP/YOI High Down
+HP	HMP Highpoint
+HI	HMP/YOI Hindley
+HB	HMP/YOI Hollesley Bay
+HH	HMP/YOI Holme House
+HL	HMP/YOI Hull
+HM	HMP Humber
+HC	HMP Huntercombe
+IS	HMP/YOI Isis
+IW	HMP/YOI Isle of Wight
+KM	HMP Kirkham
+KV	HMP/YOI Kirklevington Grange
+LF	HMP Lancaster Farms
+LE	HMP Leeds
+LC	HMP Leicester
+LW	HMP/YOI Lewes
+LY	HMP Leyhill
+LI	HMP/YOI Lincoln
+LH	HMP Lindholme
+LT	HMP Littlehey
+LP	HMP Liverpool
+LL	HMP Long Lartin
+LN	HMP/YOI Low Newton
+LG	HMP Lowdham Grange
+MS	HMP Maidstone
+MR	HMP/YOI Manchester
+MW	Medway STC
+MD	HMP/YOI Moorland
+MH	HMP Morton Hall
+MH	HMIRC Morton Hall
+NH	HMP/YOI New Hall
+NS	HMP North Sea Camp
+NL	HMP Northumberland
+NW	HMP/YOI Norwich
+NM	HMP/YOI Nottingham
+OW	HMP Oakwood
+ON	HMP Onley
+PR	HMP/YOI Parc
+PV	HMP/YOI Pentonville
+PB	HMP/YOI Peterborough
+PD	HMP/YOI Portland
+PN	HMP/YOI Preston
+RN	HMP Ranby
+RS	HMP Risley
+RC	HMP/YOI Rochester
+RH	HMP Rye Hill
+SD	HMP/YOI Send
+SF	HMP Stafford
+EH	HMP/YOI Standford Hill
+SK	HMP Stocken
+SH	HMP/YOI Stoke Heath
+ST	HMP/YOI Styal
+SU	HMP/YOI Sudbury
+SL	HMP Swaleside
+SW	HMP/YOI Swansea
+SN	HMP/YOI Swinfen Hall
+TS	HMP/YOI Thameside
+MT	HMP The Mount
+VE	HMP The Verne
+VE	HMIRC The Verne
+TC	HMP/YOI Thorn Cross
+UK	HMP Usk and HMP/YOI Prescoed
+WD	HMP Wakefield
+WW	HMP/YOI Wandsworth
+WI	HMP/YOI Warren Hill
+WL	HMP Wayland
+WE	HMP Wealstun
+WN	HMYOI Werrington
+WY	HMYOI Wetherby
+WT	HMP Whatton
+WR	HMP Whitemoor
+WC	HMP/YOI Winchester
+WH	HMP/YOI Woodhill
+WS	HMP/YOI Wormwood Scrubs
+WM	HMP/YOI Wymott
+AK	HMP Acklington		2011-10-31
+AL	HMP Albany		2009-04
+AW	HMP Ashwell		2011-03
+BT	HMP Blakenhurst		2008-06-25
+BD	HMP Blundeston		2013-09
+BK	HMP Brockhill		2008-06-25
+BU	HMP Bullwood Hall		2013-01
+CH	HMP Camp Hill		2009-04
+CY	HMP Canterbury		2013-03-31
+CS	HMP Castington		2011-10-31
+DR	HMP Dorchester		2013-12
+DV	HMIRC Dover		2015
+NE	HMP Edmunds Hill		2011-04
+EV	HMP Everthorpe		2014-04
+GL	HMP Gloucester		2013
+HR	HMIRC Haslar		2015
+HG	HMP Hewell Grange		2008-06-25
+HY	HMP Holloway		2016-05
+KT	HMP Kennet		2016-12
+PT	HMP Kingston		2013-03-28
+LM	HMP Latchmere House		2011-09
+LA	HMP Lancaster		2011-03
+NN	HMP Northallerton		2013-12
+PK	HMP Parkhurst		2009-04
+RD	HMP Reading		2013-11
+SM	HMP Shepton Mallet		2013-02-28
+SY	HMP Shrewsbury		2013-03
+WA	HMP The Weare		2006
+WB	HMP Wellingborough		2012-12-21
+WO	HMP Wolds		2014-04


### PR DESCRIPTION
Rich has agreed to remove the operator field.  Potentially we will encourage the custodian to put it back later when we have a better idea about companies.

Rejected alternatives were:
1. Leave it as a CURIE to the non-existent company register.  That's confusing.
2. Convert it to company names.  Not authoritative, not reversible.

See the parallel change in registry-data https://github.com/openregister/registry-data/pull/89.